### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,1 @@
+package-ecosystem: “bundler” # See documentation for possible values directory: “/” # Location of package manifests schedule: interval: “weekly”


### PR DESCRIPTION
To get started with Dependabot version updates, you’ll need to specify which package ecosystems to update and where the package manifests are located. Please see the documentation for all configuration options: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates